### PR TITLE
Fix .tweet-counter text-shadow and colors

### DIFF
--- a/darkmode.scss
+++ b/darkmode.scss
@@ -1139,6 +1139,18 @@
     padding: .5rem;
   }
 
+  .tweet-counter {
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.55);
+
+    &.warn {
+      color: rgb(168, 84, 36);
+    }
+
+    &.superwarn {
+      color: rgb(204, 51, 54);
+    }
+  }
+
   .content-searchbar {
     background-color: #161d27;
     border-bottom: 1px solid #2f3d51;

--- a/dist/darkmode.css
+++ b/dist/darkmode.css
@@ -981,6 +981,15 @@
     background: #090c10;
     padding: .5rem;
   }
+  .tweet-counter {
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.55);
+  }
+  .tweet-counter.warn {
+    color: #a85424;
+  }
+  .tweet-counter.superwarn {
+    color: #cc3336;
+  }
   .content-searchbar {
     background-color: #161d27;
     border-bottom: 1px solid #2f3d51;


### PR DESCRIPTION
The tweet character counter (`.tweet-count`) has a white text-shadow by default. This makes the count hard to read:
![white shadow](https://cloud.githubusercontent.com/assets/910672/23967579/2a450708-099e-11e7-9ca2-b1d365b2b70f.jpg)
The proposed change adds a softer black text-shadow:
![new shadow](https://cloud.githubusercontent.com/assets/910672/23967586/30af90cc-099e-11e7-9d84-2cff22aa7dea.jpg)

It also updates some colors: 
  * for `.warn` (<20 chars):
    ![old warn](https://cloud.githubusercontent.com/assets/910672/23968099/4540c9b4-09a0-11e7-87b7-1b6e29a113ed.jpg) changed to ![new warn](https://cloud.githubusercontent.com/assets/910672/23968098/453cc7ec-09a0-11e7-9a12-bcf6114264ff.jpg) 

  * for `.superwarn` (<10 chars):
    ![old superwarn](https://cloud.githubusercontent.com/assets/910672/23968100/454626ac-09a0-11e7-86cb-d80d852a227a.jpg) changed to ![new superwarn](https://cloud.githubusercontent.com/assets/910672/23968101/4548673c-09a0-11e7-8367-07cea14e6a01.jpg)