### PR TITLE
Fit shadow of focused items to the dark theme

### DIFF
--- a/darkmode.scss
+++ b/darkmode.scss
@@ -436,6 +436,10 @@
     }
   }
 
+  .btn:focus, .btn.focus, .Button:focus, .EmojiPicker-item.is-focused {
+    box-shadow: 0 0 0 1px rgba(206, 222, 242, 0.26), 0 0 3px 2px rgba(29, 161, 242, 0.42);
+  }
+
   .MomentCapsuleItemTweet--withText {
     background-color: #090c10;
     border-radius: 4px;

--- a/dist/darkmode.css
+++ b/dist/darkmode.css
@@ -396,6 +396,9 @@
   body a {
     color: #1c9dec;
   }
+  .btn:focus, .btn.focus, .Button:focus, .EmojiPicker-item.is-focused {
+    box-shadow: 0 0 0 1px rgba(206, 222, 242, 0.26), 0 0 3px 2px rgba(29, 161, 242, 0.42);
+  }
   .MomentCapsuleItemTweet--withText {
     background-color: #090c10;
     border-radius: 4px;


### PR DESCRIPTION
Would fix #20.

Result:
![selection_297](https://cloud.githubusercontent.com/assets/910672/23976046/acb82204-09c3-11e7-978c-e2ed9be67136.jpg)
